### PR TITLE
Make test_script portable to other mpi executables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,6 +45,8 @@ set (BUILD_SHARED_LIBS "OFF" CACHE BOOL "Build a shared library")
 include (xpkg-import)
 xpkg_import_module (margo REQUIRED margo)
 
+find_package(MPI COMPONENTS REQUIRED)
+
 add_subdirectory (src)
 if(${ENABLE_TESTS})
   enable_testing()

--- a/tests/test_script.sh.in
+++ b/tests/test_script.sh.in
@@ -11,41 +11,41 @@ lock_type = 2
 " > dataspaces.conf
 if [ $1 -eq 1 ]; then
         rm -rf servids.0
-        mpirun -n 2 dspaces_server sockets &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         sleep 5
-        mpirun -n 1 test_writer sockets 1 1 64 5 8
-        mpirun -n 1 terminator sockets
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 1 test_writer sockets 1 1 64 5 8
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 1 terminator sockets
         wait
 elif [ $1 -eq 2 ]; then
         rm -rf servids.0
-        mpirun -n 2 dspaces_server sockets &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         sleep 5
-        mpirun -n 2 test_writer sockets 1 2 64 5 8 &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer sockets 1 2 64 5 8 &
         sleep 2
-        mpirun -n 2 test_reader sockets 1 2 64 5 8
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader sockets 1 2 64 5 8
         wait
 elif [ $1 -eq 3 ]; then
         rm -rf servids.0
-        mpirun -n 2 dspaces_server sockets &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         sleep 5
-        mpirun -n 2 test_writer sockets 1 2 64 5 8 &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer sockets 1 2 64 5 8 &
         sleep 2
-        mpirun -n 2 test_reader sockets 1 2 32 5 8
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader sockets 1 2 32 5 8
         wait
 elif [ $1 -eq 4 ]; then
         rm -rf servids.0
-        mpirun -n 2 dspaces_server sockets &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         sleep 5
-        mpirun -n 2 test_writer sockets 1 2 64 5 8 &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer sockets 1 2 64 5 8 &
         sleep 2
-        mpirun -n 2 test_reader sockets 1 2 64 2 8
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader sockets 1 2 64 2 8
         wait
 elif [ $1 -eq 5 ]; then
         rm -rf servids.0
-        mpirun -n 2 dspaces_server sockets &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         sleep 3
-        mpirun -n 2 test_reader sockets 1 2 64 5 8 &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader sockets 1 2 64 5 8 &
         sleep 5
-        mpirun -n 2 test_writer sockets 1 2 64 5 8
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer sockets 1 2 64 5 8
         wait
 fi


### PR DESCRIPTION
Set mpi executable and arguments in test_script when running cmake. This should be portable to systems that use runners other than mpiexec (e.g. Summit, Cori, Theta, etc)