### PR TITLE
version 2.1.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,7 @@
 #
 
 cmake_minimum_required (VERSION 3.0)
-project (dspaces VERSION 2.1.0 LANGUAGES C)
+project (dspaces VERSION 2.1.1 LANGUAGES C)
 #enable_testing ()
 
 include(GNUInstallDirs)

--- a/include/dspaces.h
+++ b/include/dspaces.h
@@ -76,7 +76,7 @@ int dspaces_fini(dspaces_client_t client);
  * @return  0 indicates success.
  */
 int dspaces_put(dspaces_client_t client, const char *var_name, unsigned int ver,
-                int size, int ndim, uint64_t *lb, uint64_t *ub, void *data);
+                int size, int ndim, uint64_t *lb, uint64_t *ub, const void *data);
 
 /**
  * @brief Query the space to insert data specified by a geometric
@@ -279,8 +279,8 @@ void dspaces_kill(dspaces_client_t client);
  *
  * @return zero for success, non-zero for failure
  */
-int dspaces_put_meta(dspaces_client_t client, char *name, unsigned int version,
-                     void *data, unsigned int len);
+int dspaces_put_meta(dspaces_client_t client, char *name, int version,
+                     const void *data, unsigned int len);
 
 /**
  * @brief access stored metadata
@@ -305,7 +305,7 @@ int dspaces_put_meta(dspaces_client_t client, char *name, unsigned int version,
  * @param[out] len: the size of the results buffer in bytes
  */
 int dspaces_get_meta(dspaces_client_t client, char *name, int mode,
-                     unsigned int current, unsigned int *version, void **data,
+                     int current, int *version, void **data,
                      unsigned int *len);
 
 #if defined(__cplusplus)

--- a/src/dspaces-client.c
+++ b/src/dspaces-client.c
@@ -511,7 +511,7 @@ void dspaces_define_gdim(dspaces_client_t client, const char *var_name,
 }
 
 int dspaces_put(dspaces_client_t client, const char *var_name, unsigned int ver,
-                int elem_size, int ndim, uint64_t *lb, uint64_t *ub, void *data)
+                int elem_size, int ndim, uint64_t *lb, uint64_t *ub, const void *data)
 {
     hg_addr_t server_addr;
     hg_handle_t handle;
@@ -677,8 +677,8 @@ static int dspaces_init_listener(dspaces_client_t client)
     return (ret);
 }
 
-int dspaces_put_meta(dspaces_client_t client, char *name, unsigned int version,
-                     void *data, unsigned int len)
+int dspaces_put_meta(dspaces_client_t client, char *name, int version,
+                     const void *data, unsigned int len)
 {
     hg_addr_t server_addr;
     hg_handle_t handle;
@@ -944,7 +944,7 @@ int dspaces_get(dspaces_client_t client, const char *var_name, unsigned int ver,
 }
 
 int dspaces_get_meta(dspaces_client_t client, char *name, int mode,
-                     unsigned int current, unsigned int *version, void **data,
+                     int current, int *version, void **data,
                      unsigned int *len)
 {
     query_meta_in_t in;

--- a/src/dspaces.pc.in
+++ b/src/dspaces.pc.in
@@ -1,5 +1,5 @@
 prefix=@DEST_DIR@
-exec_prefix=${prefix}
+exec_prefix=${prefix}/bin
 libdir=${prefix}/lib
 includedir=${prefix}/include
 


### PR DESCRIPTION
Various bug fixes and improvements rolled up for patch release 2.1.1. This version supports the dataspaces2 engine for ADIOS2.

- Remove public linkage of margo
- put buffers changed to const for consistency with 1.x API
- fix support for global dimensions that aren't a multiple of server group size
- improve performance of writing and reading empty metadata steps