### PR TITLE
Add Scalable Init

### DIFF
--- a/include/dspaces.h
+++ b/include/dspaces.h
@@ -9,6 +9,7 @@
 #define __DSPACES_CLIENT_H
 
 #include <dspaces-common.h>
+#include <mpi.h>
 #include <stdint.h>
 
 #if defined(__cplusplus)
@@ -30,6 +31,15 @@ typedef struct dspaces_client *dspaces_client_t;
  * @return dspaces_SUCCESS or error code defined in dspaces-common.h
  */
 int dspaces_init(int rank, dspaces_client_t *client);
+
+/**
+ * @brief Creates a dspaces client. Uses MPI primitives for scalable initialization.
+ * @param[in] comm: MPI communicator for reading configuration collectively.
+ * @param[out] client dspaces client
+ *
+ * @return dspaces_SUCCESS or error code defined in dspaces-common.h
+ */
+int dspaces_init_mpi(MPI_Comm comm, dspaces_client_t *c);
 
 void dspaces_define_gdim(dspaces_client_t client, const char *var_name,
                          int ndim, uint64_t *gdim);

--- a/src/dspaces-client.c
+++ b/src/dspaces-client.c
@@ -437,7 +437,6 @@ static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm,
 
     fclose(conf);
     free(file_buf);
-    fprintf(stderr, "%d\n", client->size_sp);
 
     return (0);
 }

--- a/src/dspaces-client.c
+++ b/src/dspaces-client.c
@@ -768,7 +768,7 @@ int dspaces_put_meta(dspaces_client_t client, char *name, int version,
 
     int ret = dspaces_SUCCESS;
 
-    DEBUG_OUT("posting metadata for `%s`, version %d with lenght %i bytes.\n",
+    DEBUG_OUT("posting metadata for `%s`, version %d with length %i bytes.\n",
               name, version, len);
 
     in.name = strdup(name);

--- a/src/dspaces-client.c
+++ b/src/dspaces-client.c
@@ -18,6 +18,8 @@
 #include <sys/types.h>
 #include <unistd.h>
 
+#include<mpi.h>
+
 #define DEBUG_OUT(args...)                                                     \
     do {                                                                       \
         if(client->f_debug) {                                                  \
@@ -28,6 +30,8 @@
     } while(0);
 
 #define SUB_HASH_SIZE 16
+
+static int g_is_initialized = 0;
 
 static enum storage_type st = column_major;
 
@@ -117,6 +121,8 @@ static void choose_server(dspaces_client_t client)
 {
     int match_count = 0;
     int i;
+
+    gethostname(client->my_node_name, HOST_NAME_MAX);
 
     for(i = 0; i < client->size_sp; i++) {
         if(strcmp(client->my_node_name, client->node_names[i]) == 0) {
@@ -310,14 +316,11 @@ fini:
     return ret;
 }
 
-static int read_conf(dspaces_client_t client, char **listen_addr_str)
+FILE *open_conf_ds(dspaces_client_t client)
 {
     int wait_time, time = 0;
-    int size;
     FILE *fd;
-    fpos_t lstart;
-    int i, ret;
-
+    
     do {
         fd = fopen("conf.ds", "r");
         if(!fd) {
@@ -327,13 +330,29 @@ static int read_conf(dspaces_client_t client, char **listen_addr_str)
                           time);
             } else {
                 fprintf(stderr, "could not open config file 'conf.ds'.\n");
-                goto fini;
+                return(NULL);
             }
         }
         wait_time = (rand() % 3) + 1;
         time += wait_time;
         sleep(wait_time);
     } while(!fd);
+
+    return(fd);
+}
+
+static int read_conf(dspaces_client_t client, char **listen_addr_str)
+{
+    int size;
+    FILE *fd;
+    fpos_t lstart;
+    int i, ret;
+
+    ret = -1;
+    fd = open_conf_ds(client);
+    if(!fd) {
+        goto fini;
+    }
 
     fscanf(fd, "%d\n", &client->size_sp);
     client->server_address =
@@ -353,6 +372,7 @@ static int read_conf(dspaces_client_t client, char **listen_addr_str)
     fsetpos(fd, &lstart);
     *listen_addr_str = malloc(size + 1);
     fscanf(fd, "%s\n", *listen_addr_str);
+    fclose(fd);
 
     ret = 0;
 
@@ -360,13 +380,70 @@ fini:
     return ret;
 }
 
-int dspaces_init(int rank, dspaces_client_t *c)
+static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_addr_str)
 {
-    char *listen_addr_str;
-    const char *envdebug = getenv("DSPACES_DEBUG");
-    hg_class_t *hg;
-    static int is_initialized = 0;
+    FILE *fd, *conf;
+    struct stat st;
+    char *file_buf;
+    int file_len;
+    int rank;
+    int size;
+    fpos_t lstart;
+    int i;
 
+    MPI_Comm_rank(comm, &rank);
+    if(rank == 0) {
+        fd = open_conf_ds(client);
+        if(fd == NULL) {
+            file_len = -1;
+        } else {
+            fstat(fileno(fd), &st);
+            file_len = st.st_size;
+        }
+    }
+    MPI_Bcast(&file_len, 1, MPI_INT, 0, comm);
+    if(file_len == -1) {
+        return(-1);
+    }
+    file_buf = malloc(file_len);
+    if(rank == 0) {
+        fread(file_buf, 1, file_len, fd);
+        fclose(fd);
+    }
+    MPI_Bcast(file_buf, file_len, MPI_BYTE, 0, comm);
+
+    conf = fmemopen(file_buf, file_len, "r");
+    fscanf(conf, "%d\n", &client->size_sp);
+    client->server_address = malloc(client->size_sp * sizeof(*client->server_address));
+    client->node_names = malloc(client->size_sp * sizeof(*client->node_names));
+    for(i = 0; i < client->size_sp; i++) {
+        fgetpos(conf, &lstart);
+        fgetpos(conf, &lstart);
+        fscanf(conf, "%*s%n", &size);
+        client->node_names[i] = malloc(size + 1);
+        fscanf(conf, "%*s%n\n", &size);
+        client->server_address[i] = malloc(size + 1);
+        fsetpos(conf, &lstart);
+        fscanf(conf, "%s %s\n", client->node_names[i], client->server_address[i]);
+    }
+    fgetpos(conf, &lstart);
+    fscanf(conf, "%*s%n\n", &size);
+    fsetpos(conf, &lstart);
+    *listen_addr_str = malloc(size + 1);
+    fscanf(conf, "%s\n", *listen_addr_str);
+
+    fclose(conf);
+    free(file_buf);
+    fprintf(stderr, "%d\n", client->size_sp);
+
+    return(0);
+}
+
+static int dspaces_init_internal(int rank, dspaces_client_t *c)
+{
+    const char *envdebug = getenv("DSPACES_DEBUG");
+    static int is_initialized = 0;
+    
     if(is_initialized) {
         fprintf(stderr,
                 "DATASPACES: WARNING: %s: multiple instantiations of the "
@@ -377,12 +454,11 @@ int dspaces_init(int rank, dspaces_client_t *c)
     dspaces_client_t client = (dspaces_client_t)calloc(1, sizeof(*client));
     if(!client)
         return dspaces_ERR_ALLOCATION;
-    int i;
 
     if(envdebug) {
         client->f_debug = 1;
     }
-
+    
     client->rank = rank;
 
     // now do dcg_alloc and store gid
@@ -391,11 +467,19 @@ int dspaces_init(int rank, dspaces_client_t *c)
     if(!(client->dcg))
         return dspaces_ERR_ALLOCATION;
 
-    read_conf(client, &listen_addr_str);
-    gethostname(client->my_node_name, HOST_NAME_MAX);
+    is_initialized = 1;
 
-    choose_server(client);
+    *c = client;
 
+    return dspaces_SUCCESS;
+
+}
+
+static int dspaces_init_margo(dspaces_client_t client, const char *listen_addr_str)
+{
+    hg_class_t *hg;
+    int i;
+ 
     ABT_init(0, NULL);
 
     client->mid = margo_init(listen_addr_str, MARGO_SERVER_MODE, 0, 0);
@@ -405,8 +489,6 @@ int dspaces_init(int rank, dspaces_client_t *c)
     }
 
     hg = margo_get_class(client->mid);
-
-    free(listen_addr_str);
 
     ABT_mutex_create(&client->ls_mutex);
     ABT_mutex_create(&client->drain_mutex);
@@ -503,19 +585,77 @@ int dspaces_init(int rank, dspaces_client_t *c)
                                           HG_TRUE);
     }
 
+    return(dspaces_SUCCESS);
+}
+
+static int dspaces_post_init(dspaces_client_t client)
+{
+    choose_server(client);
+
     get_ss_info(client);
     DEBUG_OUT("Total max versions on the client side is %d\n",
               client->dcg->max_versions);
-
+   
     client->dcg->ls = ls_alloc(client->dcg->max_versions);
     client->local_put_count = 0;
     client->f_final = 0;
 
+    return(dspaces_SUCCESS); 
+}
+
+int dspaces_init(int rank, dspaces_client_t *c)
+{
+    dspaces_client_t client;
+    char *listen_addr_str;
+    int ret;
+  
+    ret = dspaces_init_internal(rank, &client);
+    if(ret != dspaces_SUCCESS) {
+        return(ret);
+    }
+
+    ret = read_conf(client, &listen_addr_str);
+    if(ret != 0) {
+        return(ret);
+    }
+
+    dspaces_init_margo(client, listen_addr_str);
+
+    free(listen_addr_str);
+
+    dspaces_post_init(client);
+
     *c = client;
 
-    is_initialized = 1;
-
     return dspaces_SUCCESS;
+}
+
+int dspaces_init_mpi(MPI_Comm comm, dspaces_client_t *c)
+{
+    dspaces_client_t client;
+    int rank;
+    char *listen_addr_str;
+    int ret;
+
+    MPI_Comm_rank(comm, &rank);
+
+    ret = dspaces_init_internal(rank, &client);
+    if(ret != dspaces_SUCCESS) {
+        return(ret);
+    }
+    
+    ret = read_conf_mpi(client, comm, &listen_addr_str);
+    if(ret != 0) {
+        return(ret);
+    }
+    dspaces_init_margo(client, listen_addr_str);
+    free(listen_addr_str);
+
+    dspaces_post_init(client);
+   
+    *c = client;
+ 
+    return(dspaces_SUCCESS);
 }
 
 static void free_done_list(dspaces_client_t client)

--- a/src/dspaces-client.c
+++ b/src/dspaces-client.c
@@ -18,7 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-#include<mpi.h>
+#include <mpi.h>
 
 #define DEBUG_OUT(args...)                                                     \
     do {                                                                       \
@@ -320,7 +320,7 @@ FILE *open_conf_ds(dspaces_client_t client)
 {
     int wait_time, time = 0;
     FILE *fd;
-    
+
     do {
         fd = fopen("conf.ds", "r");
         if(!fd) {
@@ -330,7 +330,7 @@ FILE *open_conf_ds(dspaces_client_t client)
                           time);
             } else {
                 fprintf(stderr, "could not open config file 'conf.ds'.\n");
-                return(NULL);
+                return (NULL);
             }
         }
         wait_time = (rand() % 3) + 1;
@@ -338,7 +338,7 @@ FILE *open_conf_ds(dspaces_client_t client)
         sleep(wait_time);
     } while(!fd);
 
-    return(fd);
+    return (fd);
 }
 
 static int read_conf(dspaces_client_t client, char **listen_addr_str)
@@ -380,7 +380,8 @@ fini:
     return ret;
 }
 
-static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_addr_str)
+static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm,
+                         char **listen_addr_str)
 {
     FILE *fd, *conf;
     struct stat st;
@@ -403,7 +404,7 @@ static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_a
     }
     MPI_Bcast(&file_len, 1, MPI_INT, 0, comm);
     if(file_len == -1) {
-        return(-1);
+        return (-1);
     }
     file_buf = malloc(file_len);
     if(rank == 0) {
@@ -414,7 +415,8 @@ static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_a
 
     conf = fmemopen(file_buf, file_len, "r");
     fscanf(conf, "%d\n", &client->size_sp);
-    client->server_address = malloc(client->size_sp * sizeof(*client->server_address));
+    client->server_address =
+        malloc(client->size_sp * sizeof(*client->server_address));
     client->node_names = malloc(client->size_sp * sizeof(*client->node_names));
     for(i = 0; i < client->size_sp; i++) {
         fgetpos(conf, &lstart);
@@ -424,7 +426,8 @@ static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_a
         fscanf(conf, "%*s%n\n", &size);
         client->server_address[i] = malloc(size + 1);
         fsetpos(conf, &lstart);
-        fscanf(conf, "%s %s\n", client->node_names[i], client->server_address[i]);
+        fscanf(conf, "%s %s\n", client->node_names[i],
+               client->server_address[i]);
     }
     fgetpos(conf, &lstart);
     fscanf(conf, "%*s%n\n", &size);
@@ -436,14 +439,14 @@ static int read_conf_mpi(dspaces_client_t client, MPI_Comm comm, char **listen_a
     free(file_buf);
     fprintf(stderr, "%d\n", client->size_sp);
 
-    return(0);
+    return (0);
 }
 
 static int dspaces_init_internal(int rank, dspaces_client_t *c)
 {
     const char *envdebug = getenv("DSPACES_DEBUG");
     static int is_initialized = 0;
-    
+
     if(is_initialized) {
         fprintf(stderr,
                 "DATASPACES: WARNING: %s: multiple instantiations of the "
@@ -458,7 +461,7 @@ static int dspaces_init_internal(int rank, dspaces_client_t *c)
     if(envdebug) {
         client->f_debug = 1;
     }
-    
+
     client->rank = rank;
 
     // now do dcg_alloc and store gid
@@ -472,14 +475,14 @@ static int dspaces_init_internal(int rank, dspaces_client_t *c)
     *c = client;
 
     return dspaces_SUCCESS;
-
 }
 
-static int dspaces_init_margo(dspaces_client_t client, const char *listen_addr_str)
+static int dspaces_init_margo(dspaces_client_t client,
+                              const char *listen_addr_str)
 {
     hg_class_t *hg;
     int i;
- 
+
     ABT_init(0, NULL);
 
     client->mid = margo_init(listen_addr_str, MARGO_SERVER_MODE, 0, 0);
@@ -585,7 +588,7 @@ static int dspaces_init_margo(dspaces_client_t client, const char *listen_addr_s
                                           HG_TRUE);
     }
 
-    return(dspaces_SUCCESS);
+    return (dspaces_SUCCESS);
 }
 
 static int dspaces_post_init(dspaces_client_t client)
@@ -595,12 +598,12 @@ static int dspaces_post_init(dspaces_client_t client)
     get_ss_info(client);
     DEBUG_OUT("Total max versions on the client side is %d\n",
               client->dcg->max_versions);
-   
+
     client->dcg->ls = ls_alloc(client->dcg->max_versions);
     client->local_put_count = 0;
     client->f_final = 0;
 
-    return(dspaces_SUCCESS); 
+    return (dspaces_SUCCESS);
 }
 
 int dspaces_init(int rank, dspaces_client_t *c)
@@ -608,15 +611,15 @@ int dspaces_init(int rank, dspaces_client_t *c)
     dspaces_client_t client;
     char *listen_addr_str;
     int ret;
-  
+
     ret = dspaces_init_internal(rank, &client);
     if(ret != dspaces_SUCCESS) {
-        return(ret);
+        return (ret);
     }
 
     ret = read_conf(client, &listen_addr_str);
     if(ret != 0) {
-        return(ret);
+        return (ret);
     }
 
     dspaces_init_margo(client, listen_addr_str);
@@ -641,21 +644,21 @@ int dspaces_init_mpi(MPI_Comm comm, dspaces_client_t *c)
 
     ret = dspaces_init_internal(rank, &client);
     if(ret != dspaces_SUCCESS) {
-        return(ret);
+        return (ret);
     }
-    
+
     ret = read_conf_mpi(client, comm, &listen_addr_str);
     if(ret != 0) {
-        return(ret);
+        return (ret);
     }
     dspaces_init_margo(client, listen_addr_str);
     free(listen_addr_str);
 
     dspaces_post_init(client);
-   
+
     *c = client;
- 
-    return(dspaces_SUCCESS);
+
+    return (dspaces_SUCCESS);
 }
 
 static void free_done_list(dspaces_client_t client)

--- a/src/dspaces-server.c
+++ b/src/dspaces-server.c
@@ -965,6 +965,9 @@ static int server_destroy(dspaces_provider_t server)
 
     kill_local_clients(server);
 
+    // Hack to avoid possible argobots race condition. Need to track this down at some point.
+    sleep(1);
+
     free_sspace(server->dsg);
     ls_free(server->dsg->ls);
     free(server->dsg);

--- a/src/dspaces-server.c
+++ b/src/dspaces-server.c
@@ -965,7 +965,8 @@ static int server_destroy(dspaces_provider_t server)
 
     kill_local_clients(server);
 
-    // Hack to avoid possible argobots race condition. Need to track this down at some point.
+    // Hack to avoid possible argobots race condition. Need to track this down
+    // at some point.
     sleep(1);
 
     free_sspace(server->dsg);

--- a/src/dspaces-server.c
+++ b/src/dspaces-server.c
@@ -1260,7 +1260,7 @@ static int get_query_odscs(dspaces_provider_t server, odsc_gdim_t *query,
     hndls = malloc(sizeof(*hndls) * peer_num);
 
     for(i = 0; i < peer_num; i++) {
-        DEBUG_OUT("dht servr id %d\n", de_tab[i]->rank);
+        DEBUG_OUT("dht server id %d\n", de_tab[i]->rank);
         DEBUG_OUT("self id %d\n", server->dsg->rank);
 
         if(de_tab[i]->rank == server->dsg->rank) {
@@ -1278,6 +1278,7 @@ static int get_query_odscs(dspaces_provider_t server, odsc_gdim_t *query,
 
     if(self_id_num > -1) {
         podsc = malloc(sizeof(*podsc) * ssd->ent_self->odsc_num);
+        DEBUG_OUT("finding local entries.\n");
         odsc_nums[self_id_num] =
             dht_find_entry_all(ssd->ent_self, q_odsc, &podsc, timeout);
         DEBUG_OUT("%d odscs found in %d\n", odsc_nums[self_id_num],

--- a/src/ss_data.c
+++ b/src/ss_data.c
@@ -1,4 +1,5 @@
 /*
+p
  * Copyright (c) 2009, NSF Cloud and Autonomic Computing Center, Rutgers
  * University All rights reserved.
  *
@@ -1747,7 +1748,7 @@ struct meta_data *meta_find_next_entry(ss_storage *ls, const char *name,
         list = &ls->meta_hash[index];
         list_for_each_entry(mdata, list, struct meta_data, entry)
         {
-            if(strcmp(mdata->name, name) == 0 && mdata->version > curr &&
+            if(strcmp(mdata->name, name) == 0 && (int)mdata->version > curr &&
                (!mdres || mdata->version < mdres->version)) {
                 mdres = mdata;
                 if(mdata->version < (curr + ls->size_hash)) {

--- a/tests/test_put_run.c
+++ b/tests/test_put_run.c
@@ -17,6 +17,8 @@
 static int np[10] = {0};
 // block size per processor per direction
 static uint64_t sp[10] = {0};
+// global data dimensions
+static uint64_t gdim[10] = {0};
 //# of interations
 static int timesteps_;
 //# of processors in the application
@@ -102,9 +104,6 @@ static int couple_write_nd(dspaces_client_t ndph, unsigned int ts, int num_vars,
         data_tab[i] = data;
     }
 
-    MPI_Barrier(gcomm_);
-    tm_st = timer_read(&timer_);
-
     if(rank_ == root) {
         err = dspaces_put_meta(ndph, "mnd", ts, &elem_size, sizeof(elem_size));
         if(err != 0) {
@@ -112,6 +111,9 @@ static int couple_write_nd(dspaces_client_t ndph, unsigned int ts, int num_vars,
             return (err);
         }
     }
+
+    MPI_Barrier(gcomm_);
+    tm_st = timer_read(&timer_);
 
     for(i = 0; i < num_vars; i++) {
         sprintf(var_name, "mnd_%d", i);
@@ -145,6 +147,26 @@ static int couple_write_nd(dspaces_client_t ndph, unsigned int ts, int num_vars,
     return 0;
 }
 
+int set_gdims(dspaces_client_t client, int num_vars, int ndims, uint64_t *dims)
+{
+    char var_name[128];
+    int i, ret;
+
+    for(i = 0; i < num_vars; i++) {
+        sprintf(var_name, "mnd_%d", i);
+        dspaces_define_gdim(client, var_name, ndims, dims);
+    }
+    if(rank_ == 0) {
+        ret = dspaces_put_meta(client, "gdim", 0, dims, sizeof(*dims) * 10);
+        if(ret != 0) {
+            fprintf(stderr, "dspaces_put_meta() failed with %d.\n", ret);
+            return (ret);
+        }
+    }
+
+    return (0);
+}
+
 int test_put_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
                  size_t elem_size, int num_vars, int local_mode, int terminate,
                  MPI_Comm gcomm)
@@ -161,6 +183,7 @@ int test_put_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
     for(i = 0; i < ndims; i++) {
         np[i] = npdim[i];
         sp[i] = spdim[i];
+        gdim[i] = np[i] * sp[i];
     }
 
     timer_init(&timer_, 1);
@@ -176,6 +199,12 @@ int test_put_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
     tm_end = timer_read(&timer_);
     fprintf(stdout, "TIMING_PERF Init_server_connection peer %d time= %lf\n",
             rank_, tm_end - tm_st);
+
+    ret = set_gdims(ndcl, num_vars, ndims, gdim);
+    if(ret != 0) {
+        ret = -1;
+        goto error;
+    }
 
     MPI_Comm_size(gcomm_, &nproc_);
 

--- a/tests/test_put_run.c
+++ b/tests/test_put_run.c
@@ -194,7 +194,11 @@ int test_put_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
 
     MPI_Comm_rank(gcomm_, &rank_);
 
-    ret = dspaces_init(rank_, &ndcl);
+    ret = dspaces_init_mpi(gcomm_, &ndcl);
+    if(ret != dspaces_SUCCESS) {
+        fprintf(stderr, "dspaces_init_mpi() failed with %d.\n", ret);
+        goto error;
+    }
 
     tm_end = timer_read(&timer_);
     fprintf(stdout, "TIMING_PERF Init_server_connection peer %d time= %lf\n",

--- a/tests/test_reader.c
+++ b/tests/test_reader.c
@@ -44,7 +44,7 @@ int parse_args(int argc, char **argv, int *dims, int *npdim, uint64_t *spdim,
     char **argp;
     int i;
 
-    *elem_size = 8;
+    *elem_size = 0;
     *num_vars = 1;
     *dims = 1;
     *terminate = 0;

--- a/tests/test_script.sh.in
+++ b/tests/test_script.sh.in
@@ -24,19 +24,15 @@ if [ $1 -eq 1 ]; then
         if [ $? != 0 ] ; then
             exit 1
         fi
-        #if [ "$storage_mode" == "local" ] ; then
-        #    @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 terminator
-        #else
-            @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 1 terminator
-        #fi
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 1 terminator
         wait $serverproc || exit 1
         wait $wproc
 elif [ $1 -eq 2 ]; then
         @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 dspaces_server sockets &
         serverproc=$!
-        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer 1 2 64 5 -s 8 -m $storage_mode -t &
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_writer 1 2 64 5 -m $storage_mode -t &
         writerproc=$!
-        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader 1 2 64 5 -s 8 -t
+        @MPIEXEC_EXECUTABLE@ @MPIEXEC_NUMPROC_FLAG@ 2 test_reader 1 2 64 5 -t
         if [ $? != 0 ] ; then
             exit 1
         fi

--- a/tests/test_sub_run.c
+++ b/tests/test_sub_run.c
@@ -9,6 +9,7 @@
 #include "timer.h"
 #include <dspaces.h>
 #include <errno.h>
+#include <inttypes.h>
 #include <margo.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -18,6 +19,8 @@
 static int np[10] = {0};
 // block size per processor per direction
 static uint64_t sp[10] = {0};
+// global dimensions
+static uint64_t gdim[10] = {0};
 //# of interations
 static int timesteps_;
 //# of processors in the application
@@ -159,6 +162,60 @@ static int couple_sub_nd(dspaces_client_t client, unsigned int ts, int num_vars,
     return ret;
 }
 
+int get_gdims(dspaces_client_t client, int num_vars, int ndims, MPI_Comm gcomm)
+{
+    char var_name[128];
+    int mver;
+    unsigned int mlen;
+    void *mdata;
+    int i, ret;
+    int root = 0;
+
+    if(rank_ == root) {
+        ret = dspaces_get_meta(client, "gdim", META_MODE_NEXT, -1, &mver,
+                               &mdata, &mlen);
+        if(ret != 0) {
+            fprintf(stderr, "dspaces_get_meta() failed with %d\n", ret);
+            return (ret);
+        }
+        if(mver != 0) {
+            fprintf(stderr, "gdim metadata is version %d, shoud be 0!\n", mver);
+            return (-1);
+        }
+        if(mlen != sizeof(*gdim) * 10) {
+            fprintf(stderr,
+                    "gdim metadata is the wrong size. Expected %li bytes and "
+                    "got %i!\n",
+                    sizeof(*gdim) * 1, mlen);
+            return (0);
+        }
+        memcpy(gdim, mdata, sizeof(*gdim) * 10);
+        free(mdata);
+        fprintf(stdout, "Global writer dimensions: (");
+        for(i = 0; i < 10; i++) {
+            if(i < ndims) {
+                fprintf(stdout, "%" PRIu64 ", ", gdim[i]);
+            } else if(gdim[i] != 0) {
+                fprintf(stderr,
+                        "ndim mismatch between writer and reader, or metadata "
+                        "corruption. Non-zero entry in dimension %d.\n",
+                        i);
+                return (-1);
+            }
+        }
+        fprintf(stdout, ")\n");
+    }
+
+    MPI_Bcast(gdim, sizeof(*gdim) * 10, MPI_BYTE, root, gcomm);
+
+    for(i = 0; i < num_vars; i++) {
+        sprintf(var_name, "mnd_%d", i);
+        dspaces_define_gdim(client, var_name, ndims, gdim);
+    }
+
+    return (0);
+}
+
 int test_sub_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
                  size_t elem_size, int num_vars, int terminate, MPI_Comm gcomm)
 {
@@ -196,6 +253,8 @@ int test_sub_run(int ndims, int *npdim, uint64_t *spdim, int timestep,
     tm_end = timer_read(&timer_);
     fprintf(stdout, "TIMING_PERF Init_server_connection peer %d time= %lf\n",
             rank_, tm_end - tm_st);
+
+    get_gdims(ndcl, num_vars, ndims, gcomm);
 
     sub_handles = malloc(sizeof(*sub_handles) * timesteps_);
 


### PR DESCRIPTION
Add scalable init call, `dspaces_init_mpi()`, to avoid every rank reading the conf.ds file.