### PR TITLE
Add non-blocking put

### DIFF
--- a/include/dspaces.h
+++ b/include/dspaces.h
@@ -19,6 +19,9 @@ extern "C" {
 typedef struct dspaces_client *dspaces_client_t;
 #define dspaces_CLIENT_NULL ((dspaces_client_t)NULL)
 
+typedef struct dspaces_put_req *dspaces_put_req_t;
+#define dspaces_PUT_NULL ((dspaces_put_req_t)NULL)
+
 #define META_MODE_SPEC 1
 #define META_MODE_NEXT 2
 #define META_MODE_LAST 3
@@ -33,7 +36,8 @@ typedef struct dspaces_client *dspaces_client_t;
 int dspaces_init(int rank, dspaces_client_t *client);
 
 /**
- * @brief Creates a dspaces client. Uses MPI primitives for scalable initialization.
+ * @brief Creates a dspaces client. Uses MPI primitives for scalable
+ * initialization.
  * @param[in] comm: MPI communicator for reading configuration collectively.
  * @param[out] client dspaces client
  *
@@ -86,7 +90,59 @@ int dspaces_fini(dspaces_client_t client);
  * @return  0 indicates success.
  */
 int dspaces_put(dspaces_client_t client, const char *var_name, unsigned int ver,
-                int size, int ndim, uint64_t *lb, uint64_t *ub, const void *data);
+                int size, int ndim, uint64_t *lb, uint64_t *ub,
+                const void *data);
+
+/**
+ * @brief Non-blocking query of the space to insert data specified by a
+ * geometric descriptor.
+ *
+ * Memory buffer pointed by pointer "data" is a sub-region of the
+ * global n-dimensional array in user application, which is described
+ * by the local bounding box {(lb[0],lb[1],..,lb[n-1]),
+ * (ub[0],ub[1],..,ub[n-1])}.
+ *
+ * This routine is non-blocking, and successful return of the routine does not
+ * guarantee the completion of data transfer from client process to dataspaces
+ * staging server.
+ *
+ * Note: ordering of dimension (fast->slow) is 0, 1, ..., n-1. For C row-major
+ * array, the dimensions need to be reordered to construct the bounding box. For
+ * example, the bounding box for C array c[2][4] is lb: {0,0}, ub: {3,1}.
+ *
+ * @param[in] client: dspaces client
+ * @param[in] var_name:     Name of the variable.
+ * @param[in] ver:      Version of the variable.
+ * @param[in] size:     Size (in bytes) for each element of the global
+ *              array.
+ * @param[in] ndim:     the number of dimensions for the local bounding
+ *              box.
+ * @param[in] lb:       coordinates for the lower corner of the local
+ *                  bounding box.
+ * @param[in] ub:       coordinates for the upper corner of the local
+ *                  bounding box.
+ * @param[in] data:     Pointer to user data buffer.
+ *
+ * @return put handle
+ */
+struct dspaces_put_req *dspaces_iput(dspaces_client_t client,
+                                     const char *var_name, unsigned int ver,
+                                     int size, int ndim, uint64_t *lb,
+                                     uint64_t *ub, const void *data);
+
+/**
+ * @brief Check status of non-blocking put
+ *
+ * Check completion status of non-blocking put.
+ *
+ * @param[in] client: dspaces client
+ * @param[in] req: put request handle
+ * @param[in] wait: wait for request to complete
+ *
+ * @return 0 indicates success
+ */
+int dspaces_check_put(dspaces_client_t client, struct dspaces_put_req *req,
+                      int wait);
 
 /**
  * @brief Query the space to insert data specified by a geometric

--- a/tests/test_script.sh.in
+++ b/tests/test_script.sh.in
@@ -1,5 +1,6 @@
 #!/bin/bash -e
 export PATH="@CMAKE_RUNTIME_OUTPUT_DIRECTORY@:${PATH}"
+export LD_LIBRARY_PATH="@CMAKE_LIBRARY_OUTPUT_DIRECTORY@:${LD_LIBRARY_PATH}"
 
 storage_mode=$2
 storage_mode=${storage_mode:=server}

--- a/tests/test_writer_server.c
+++ b/tests/test_writer_server.c
@@ -42,7 +42,6 @@ void print_usage()
         "   -t                - send server termination after writing is "
         "complete\n"
         "   -i                - use nonblocking puts (dspaces_iput)\n");
-        
 }
 
 int parse_args(int argc, char **argv, int *dims, int *npdim, uint64_t *spdim,
@@ -132,7 +131,8 @@ int parse_args(int argc, char **argv, int *dims, int *npdim, uint64_t *spdim,
 int main(int argc, char **argv)
 {
     char *listen_addr_str;
-    int dims, timestep, num_vars, local_mode, terminate, nonblock, npapp, nprocs;
+    int dims, timestep, num_vars, local_mode, terminate, nonblock, npapp,
+        nprocs;
     int np[10] = {0};
     uint64_t sp[10] = {0};
     size_t elem_size;


### PR DESCRIPTION
Add non-blocking puts. Current `dspaces_put` is blocking and waits until the written data has been transferred to a server to return. This means that the `data` buffer can be immediately reused, but it also introduces significant writer-side delays waiting for network traffic to complete.

This PR adds `dspaces_iput`, which sends a one-sided RPC and returns. iput returns a request handle that the user can call `dspaces_check_put` on to check the status of the transfer, with the option to block in dspaces_check_put until the transfer completes. The user _must_ wait for the transfer to complete to reuse the data buffer passed to iput, else risk corruption of the transferring data.

The client waits for all outstanding iputs to complete during finalize.