### PR TITLE
Add API calls to access local storage objects on server

### DIFF
--- a/include/dspaces-server.h
+++ b/include/dspaces-server.h
@@ -10,6 +10,7 @@
 
 #include <dspaces-common.h>
 #include <mpi.h>
+#include <stdint.h>
 #include <stdio.h>
 
 #if defined(__cplusplus)
@@ -21,16 +22,26 @@ extern "C" {
 typedef struct dspaces_provider *dspaces_provider_t;
 #define dspaces_PROVIDER_NULL ((dspaces_provider_t)NULL)
 
+struct dspaces_data_obj {
+    const char *var_name;
+    int version;
+    int ndim;
+    int size;
+    uint64_t *lb;
+    uint64_t *ub;
+};
+
 /**
  * @brief Creates a MESSAGING server.
  *
- * @param[in] listen_addr_str mercury-interpeted network string 
+ * @param[in] listen_addr_str mercury-interpeted network string
  * @param[in] comm MPI Communicator
- * @param[in] conf_file DataSpaces configuration file *.toml parsed as TOML, else legacy 
+ * @param[in] conf_file DataSpaces configuration file *.toml parsed as TOML,
+ * else legacy
  * @param[out] server DataSpaces server handle
  */
-int dspaces_server_init(char *listen_addr_str, MPI_Comm comm, const char *conf_file,
-                        dspaces_provider_t *server);
+int dspaces_server_init(char *listen_addr_str, MPI_Comm comm,
+                        const char *conf_file, dspaces_provider_t *server);
 
 /**
  * @brief Waits for the dataspaces server to finish (be killed.)
@@ -39,6 +50,32 @@ int dspaces_server_init(char *listen_addr_str, MPI_Comm comm, const char *conf_f
  *
  */
 void dspaces_server_fini(dspaces_provider_t server);
+
+/**
+ * @brief Retrieves list of data objects for a given variable/version pair.
+ *
+ * @param[in] server DataSpaces server handle
+ * @param[in] var_name Name of variable to query
+ * @param[in] version version for which to query
+ * @param[out] objs list data objects in local storage that match the query.
+ *
+ * @return Number of objs found. Negative numbers indicate failure.
+ */
+int dspaces_server_find_objs(dspaces_provider_t server, const char *var_name,
+                             int version, struct dspaces_data_obj **objs);
+
+/**
+ * @brief Retrieves data from a local storage object
+ *
+ * @param[in] server DataSpaces server handle
+ * @param[in] obj Data object for which to retrieve the data
+ * @param[out] buffer Buffer into which to copy the object data. Must be large
+ * enough receive all the data of obj
+ *
+ * @return 0 for success, non-zero if the data cannot be retrieved.
+ */
+int dspaces_server_get_objdata(dspaces_provider_t server,
+                               struct dspaces_data_obj *obj, void *buffer);
 
 #if defined(__cplusplus)
 }

--- a/include/ss_data.h
+++ b/include/ss_data.h
@@ -331,7 +331,7 @@ void ls_remove(ss_storage *, struct obj_data *);
 void ls_try_remove_free(ss_storage *, struct obj_data *);
 struct obj_data *ls_find(ss_storage *, obj_descriptor *);
 struct obj_data *ls_find_od(ss_storage *, obj_descriptor *);
-int ls_find_ods(ss_storage *, obj_descriptor *, struct obj_data **);
+int ls_find_ods(ss_storage *ls, obj_descriptor *odsc, obj_descriptor ***od_tab);
 struct obj_data *ls_find_no_version(ss_storage *, obj_descriptor *);
 
 struct obj_data *obj_data_alloc(obj_descriptor *);

--- a/src/ss_data.c
+++ b/src/ss_data.c
@@ -1019,10 +1019,19 @@ struct obj_data *ls_find(ss_storage *ls, obj_descriptor *odsc)
 }
 
 /*
+ * Do two object descriptors have the same name and version?
+ */
+static int obj_desc_match(obj_descriptor *odsc1, obj_descriptor *odsc2)
+{
+    return (odsc1->version == odsc2->version &&
+            strcmp(odsc1->name, odsc2->name) == 0);
+}
+
+/*
   Find  list of object_desriptors  in the  local storage  that has  the same
-  name and version with the object descriptor 'odsc'.
+  name and version as the object descriptor 'odsc'.
 */
-int ls_find_ods(ss_storage *ls, obj_descriptor *odsc, struct obj_data **od_tab)
+int ls_find_ods(ss_storage *ls, obj_descriptor *odsc, obj_descriptor ***od_tab)
 {
     struct obj_data *od;
     struct list_head *list;
@@ -1033,8 +1042,16 @@ int ls_find_ods(ss_storage *ls, obj_descriptor *odsc, struct obj_data **od_tab)
     list = &ls->obj_hash[index];
     list_for_each_entry(od, list, struct obj_data, obj_entry)
     {
-        if(obj_desc_equals_intersect(odsc, &od->obj_desc)) {
-            od_tab[num_odsc++] = od;
+        if(obj_desc_match(odsc, &od->obj_desc)) {
+            num_odsc++;
+        }
+    }
+    *od_tab = malloc(sizeof(**od_tab) * num_odsc);
+    num_odsc = 0;
+    list_for_each_entry(od, list, struct obj_data, obj_entry)
+    {
+        if(obj_desc_match(odsc, &od->obj_desc)) {
+            (*od_tab)[num_odsc++] = &od->obj_desc;
         }
     }
     return num_odsc;


### PR DESCRIPTION
Adds two API calls:

`dspaces_server_find_objs()` - gets a list of local storage objects with a given name and version

`dspaces_server_get_objdata()` - copies the full data of an object from local storage into a user-provided buffer