### PR TITLE
Add direct call of module queries.

### DIFF
--- a/bindings/python/dspaces.py
+++ b/bindings/python/dspaces.py
@@ -90,6 +90,24 @@ class DSClient:
         passed_type = None if dtype == None else np.dtype(dtype)
         return wrapper_dspaces_get(self.client, (self.nspace + name).encode('ascii'), version, lb, ub, passed_type, timeout)    
 
+    def GetModule(self, module, params = {}):
+        if not isinstance(module, str):
+            raise TypeError("module should be a module name")
+        if not isinstance(params, dict):
+            raise TypeError("params should be a dictionary.")
+        serialized_params = {key: json.dumps(val) for key,val in params.items()}
+        result, err = wrapper_dspaces_get_module(self.client, module.encode('ascii'), serialized_params)
+        if err < 0:
+            if err == -3:
+                raise DSModuleError(err)
+            elif err == -2 or err == -1 or err == -4 or err == -5:
+                raise DSRemoteFaultError(err)
+            elif err == -6:
+                raise DSConnectionError(err)
+            else:
+                raise Exception("unknown failure")
+        return(result)
+
     def Exec(self, name, version, lb=None, ub=None, fn=None):
         arg = DSObject(name=name, version=version, lb=lb, ub=ub)
         return(self.VecExec([arg], fn))

--- a/bindings/python/dspaces_wrapper.h
+++ b/bindings/python/dspaces_wrapper.h
@@ -26,6 +26,9 @@ PyObject *wrapper_dspaces_get(PyObject *clientppy, const char *name,
                               int version, PyObject *lbt, PyObject *ubt,
                               PyObject *dtype, int timeout);
 
+PyObject *wrapper_dspaces_get_module(PyObject *clientppy, const char *module,
+                                     PyObject *params);
+
 PyObject *wrapper_dspaces_pexec(PyObject *clientppy, PyObject *req_list,
                                 PyObject *fn, const char *fn_name);
 

--- a/include/dspaces-common.h
+++ b/include/dspaces-common.h
@@ -11,6 +11,10 @@
 #include <stdio.h>
 #include <stdlib.h>
 
+#include <margo.h>
+
+#include "dspaces-logging.h"
+
 #if defined(__cplusplus)
 extern "C" {
 #endif
@@ -61,6 +65,8 @@ static inline void ignore_result(int unused_result) { (void)unused_result; }
 #define DSP_INT16 -15
 #define DSP_INT32 -16
 #define DSP_INT64 -17
+#define DSP_STR -18
+#define DSP_JSON -19
 
 static size_t type_to_size_map[] = {0,
                                     sizeof(float),
@@ -89,6 +95,16 @@ static int type_to_size(int type_id)
     }
     return (type_to_size_map[-type_id]);
 }
+
+#define HG_TRY(op, ret, jmp, estr, ...)                                        \
+    do {                                                                       \
+        hg_return_t hret = op;                                                 \
+        if(hret != HG_SUCCESS) {                                               \
+            DEBUG_OUT(estr, ##__VA_ARGS__);                                    \
+            err = ret;                                                         \
+            goto jmp;                                                          \
+        }                                                                      \
+    } while(0);
 
 #if defined(__cplusplus)
 }

--- a/include/dspaces-modules.h
+++ b/include/dspaces-modules.h
@@ -25,7 +25,9 @@ struct dspaces_module {
 typedef enum dspaces_module_arg_type {
     DSPACES_ARG_REAL,
     DSPACES_ARG_INT,
+    DSPACES_ARG_BOOL,
     DSPACES_ARG_STR,
+    DSPACES_ARG_JSON,
     DSPACES_ARG_NONE
 } dspaces_mod_arg_type_t;
 
@@ -68,6 +70,10 @@ struct dspaces_module_ret {
 
 int dspaces_init_mods(struct list_head *mods);
 
+int build_module_args_from_dict(size_t dict_len, int8_t *types, char **keys,
+                                void **vals,
+                                struct dspaces_module_args **argsp);
+
 int build_module_args_from_odsc(obj_descriptor *odsc,
                                 struct dspaces_module_args **argsp);
 
@@ -90,5 +96,8 @@ struct dspaces_module_ret *dspaces_module_exec(struct dspaces_module *mod,
                                                int nargs, int ret_type);
 
 int dspaces_module_names(struct list_head *mods, char ***names);
+
+int odsc_from_ret(struct dspaces_module_ret *ret, obj_descriptor **odsc_out,
+                  char name[OD_MAX_NAME_LEN], int version);
 
 #endif // __DSPACES_MODULES_H__

--- a/include/dspaces.h
+++ b/include/dspaces.h
@@ -314,6 +314,29 @@ struct dspaces_req {
 int dspaces_get_req(dspaces_client_t client, struct dspaces_req *in_req,
                     struct dspaces_req *out_req, int timeout);
 
+struct dspaces_mod_param {
+    int type;
+    char *key;
+    union {
+        float f;
+        double d;
+        int8_t b : 1;
+        int8_t i8;
+        int16_t i16;
+        int32_t i32;
+        int64_t i64;
+        uint8_t u8;
+        uint16_t u16;
+        uint32_t u32;
+        uint64_t u64;
+        char *s;
+    } val;
+};
+
+int dspaces_get_module(dspaces_client_t client, const char *module,
+                       struct dspaces_mod_param *params, int num_param,
+                       struct dspaces_req *out);
+
 int dspaces_pexec(dspaces_client_t client, const char *var_name,
                   unsigned int ver, int ndim, uint64_t *lb, uint64_t *ub,
                   const char *fn, unsigned int fnsz, const char *fn_name,

--- a/modules/azure_mod.py
+++ b/modules/azure_mod.py
@@ -1,71 +1,74 @@
-import planetary_computer
-from netCDF4 import Dataset
-import fsspec
-import pystac_client
-import numpy as np
-import os
-from urllib.parse import urlparse
-from urllib.request import urlretrieve
-from bitstring import Bits, pack
-from datetime import date, timedelta
+import planetary_computer 
+from netCDF4 import Dataset 
+import pystac_client 
+import numpy as np 
+import os 
+from urllib.parse import urlparse 
+from urllib.request import urlretrieve 
+from bitstring import Bits, pack 
+from datetime import date, timedelta 
+from dateutil import parser 
 import sys
 
 base_date = date(1950, 1, 1)
 present_date = date(2015, 1, 1)
 last_date = date(2100, 12, 31)
-cache_base='.azrcache'
+cache_base = '.azrcache'
 
-try:
-    catalog = pystac_client.Client.open(
-        "https://planetarycomputer.microsoft.com/api/stac/v1",
-        modifier=planetary_computer.sign_inplace,
-    )
+try: 
+    catalog = pystac_client.Client.open("https://planetarycomputer.microsoft.com/api/stac/v1", 
+                                        modifier = planetary_computer.sign_inplace, ) 
     collection = catalog.get_collection("nasa-nex-gddp-cmip6")
-    variable_list=collection.summaries.get_list("cmip6:variable")
-    model_list=collection.summaries.get_list("cmip6:model")[:10]
-    scenario_list=collection.summaries.get_list("cmip6:scenario")
-    have_pc = True
+    variable_list = collection.summaries.get_list("cmip6:variable")
+    model_list = collection.summaries.get_list("cmip6:model")[ : 10] 
+    scenario_list = collection.summaries.get_list("cmip6:scenario")
+    have_pc = True 
 except pystac_client.exceptions.APIError:
-    print("don't have planetary computer api access")
+    print("don't have planetary computer api access") 
     have_pc = False
 
+                                                                                                                                                                                                                                                                                                                                                                                                                                                                          
 def _get_gddp_time_ranges(version):
-    bits = Bits(uint=version, length=32)
+    bits = Bits(uint = version, length = 32) 
     start_day, span_days = bits.unpack('uint:16, uint:16')
     start_date = base_date + timedelta(days = start_day)
-    end_date = start_date + timedelta(days = span_days)
+    end_date = start_date + timedelta(days = span_days) 
     if start_date > last_date:
-        raise ValueError(f'WARNING: start_date of {start_date} is too far in the future')
+        raise ValueError(f'WARNING: start_date of {start_date} is too far in the future') 
     if end_date > last_date:
-        print(f"WARNING: truncating end_date of {end_date} to {last_date}")
-        end_date = last_date
+        print(f'WARNING: truncating end_date of {end_date} to {last_date}')
+        end_date = last_date 
     return start_date, end_date
 
+def _validate_gddp_params(gparams):
+    model = gparams.get('model', 'NO MODEL')
+    scenario = gparams.get('scenario', 'NO SCENARIO')
+    variable = gparams.get('variable', 'NO VARIABLE') 
+    if model not in model_list:
+        raise ValueError(f'model {model} not available.')
+    if scenario not in scenario_list:
+        raise ValueError(f'scenario {scenario} not available.')
+    if variable not in variable_list:
+        raise ValueError(f'variable {variable} not available.')
+
+def _get_default_params(): 
+    return {'model' : 'CESM2', 'scenario' : 'ssp585', 'variable' : None }
+
 def _get_gddp_params(name):
-    model = 'CESM2'
-    scenario = 'ssp585'
-    variable = None
-    var_name = name.split('\\')[-1]
-    quality = 0
+    gddp_params = _get_default_params()
+    var_name = name.split('\\')[- 1]
     name_parts = var_name.split(',')
-    for part in name_parts:
+    for part in name_parts: 
         if part[0] == 'm':
-            model = part[2:]
-            if have_pc and model not in model_list:
-                raise ValueError(f"model {model} not available.") 
+            gddp_params['model'] = part[2 : ] 
         if part[0] == 's':
-            scenario = part[2:]
-            if have_pc and scenario not in scenario_list:
-                raise ValueError(f"scenario {scenario} not available.")
+            gddp_params['scenario'] = part[2 : ]
         if part[0] == 'v':
-            variable = part[2:]
-            if have_pc and variable not in variable_list:
-                raise ValueError(f"variable {variable} not available.")
-        if part[0] == 'q':
-            quality = int(part[2:])
-    if variable == None:
-        raise ValueError('No variable name specified')
-    return model, scenario, variable, quality
+            gddp_params['variable'] = part[2 : ]
+        if 'variable' not in gddp_params:
+            raise ValueError('No variable name specified') 
+    _validate_gddp_params(gddp_params)
+    return gddp_params
 
 def _get_dataset(url):
     path = urlparse(url).path
@@ -73,84 +76,150 @@ def _get_dataset(url):
     if not os.path.exists(cache_entry):
         cache_dir = os.path.dirname(cache_entry)
         if not os.path.exists(cache_dir):
-            os.makedirs(os.path.dirname(cache_entry))
-        urlretrieve(url, filename=cache_entry)
-    return(Dataset(cache_entry))
+            os.makedirs(os.path.dirname(cache_entry)) 
+        urlretrieve(url, filename = cache_entry) 
+    return Dataset(cache_entry)
 
 def _get_azure_url(url, var_name):
-    ds = _get_dataset(url)
-    return(ds[var_name])
+    ds = _get_dataset(url) 
+    return ds[var_name]
 
-def _get_cmip6_data(model, scenario, variable, start_date, end_date, lb, ub):
-    result = None
-    result_days = (end_date - start_date).days + 1
-    if have_pc:
-        search = catalog.search(
-                collections=["nasa-nex-gddp-cmip6"],
-                datetime=f'{start_date}/{end_date}',
-                query = {
-                    "cmip6:model": {
-                        "eq": model
-                    },
-                    "cmip6:scenario": {
-                        "in": ['historical', scenario]
-                    },  
-                },
-                sortby=[{'field':'cmip6:year','direction':'asc'}]
-        )
-        items = search.item_collection()
-            
+def _get_urls(start_date, end_date, model, scenario, variable):
+    url_list = []
+    search = catalog.search(collections = ["nasa-nex-gddp-cmip6"],
+                            datetime = f'{start_date}/{end_date}', 
+                            query = {"cmip6:model" : {"eq" : model }, 
+                                     "cmip6:scenario" : {"in" : ['historical', scenario] }, }, 
+                            sortby = [{'field' : 'cmip6:year', 'direction' : 'asc' }]) 
+    items = search.item_collection()
     for item in items:
-        if have_pc:
-            year = item.properties['cmip6:year']
-            url = item.assets[variable].href
-            ds = _get_dataset(url)
-        else:
-            # TODO - in case indexing is offline, we still want to hit the cache
-            pass
+        year = item.properties['cmip6:year']
+        url = item.assets[variable].href
+        url_list.append((year, url)) 
+    return url_list
+
+def _get_cmip6_data(start_date, end_date, lb, ub, model, scenario, variable):
+    result = None 
+    result_days = (end_date - start_date).days + 1
+
+    url_list = _get_urls(start_date, end_date, model, scenario, variable)
+
+    for year, url in url_list:
+        ds = _get_dataset(url) 
         data = ds[variable]
-        if result is None:
-            if lb[0] >= data[0].shape[0] or lb[1] >= data[0].shape[1]:
-                return None
-            ub = (min(ub[0]+1, data[0].shape[0]), min(ub[1]+1, data[0].shape[1]))
+        if result is None: 
+            if lb[0] >= data[0].shape[0] or lb[1] >= data[0].shape[1]: 
+                return None 
+            ub = (min(ub[0] + 1, data[0].shape[0]), min(ub[1] + 1, data[0].shape[1])) 
             shape = (result_days, ub[0] - lb[0], ub[1] - lb[1])
             result = np.ndarray(shape, dtype = data.dtype)
-        item_start = max(start_date, date(year, 1,1))
-        item_end = min(date(year,12,31), end_date)
-        start_gidx = (item_start - start_date).days
-        end_gidx = (item_end - start_date).days + 1
-        start_iidx = (item_start - date(year, 1 , 1)).days
-        end_iidx = (item_end - date(year, 1, 1)).days + 1
-        result[start_gidx:end_gidx,:,:] = data[start_iidx:end_iidx,lb[0]:ub[0],lb[1]:ub[1]]
-    return(result)
+        item_start = max(start_date, date(year, 1, 1)) 
+        item_end = min(date(year, 12, 31), end_date)
+        start_gidx =(item_start - start_date).days
+        end_gidx =(item_end - start_date).days + 1
+        start_iidx =(item_start - date(year, 1, 1)).days
+        end_iidx =(item_end - date(year, 1, 1)).days + 1 
+        result[start_gidx:end_gidx, :, : ] = data[start_iidx:end_iidx, lb[0] :ub[0], lb[1] :ub[1]] 
+        return result
 
-def validate(url, **kwargs):
+def validate(start_date, end_date, variable, **kwargs):
     pass
 
-def reg_query(name, version, lb, ub, params, url, var_name):
-    array = _get_azure_url(url, var_name)
-    if lb:
-        index = [ slice(lb[x], ub[x]+1) for x in range(len(lb)) ]
+def _get_reg_time_bounds(params, start_date, end_date):
+    query_time = params.get('query_time')
+    if query_time:
+        query_start = parser.parse(query_time)
+        query_end = parser.parse(query_time) 
     else:
-        index = [ slice(0, x) for x in array.shape]
-    return(array[index])
+        query_start = parser.parse(params.get('query_start'))
+        query_end = parser.parse(params.get('query_end'))
+    start_date = parser.parse(start_date)
+    end_date = parser.parse(end_date)
+    query_start = max(query_start, start_date)
+    query_end = min(query_end, end_date)
+    result_start = (query_start - start_date).days
+    result_end =(query_end - start_date).days 
+    
+    return result_start, result_end
 
+def _get_reg_params(variable, model, scenario):
+    gddp_params = _get_default_params() 
+    gddp_params['variable'] = variable 
+    if model:
+        gddp_params['model'] = model
+    if scenario:
+        gddp_params['scenario'] = scenario 
+    return gddp_params
+
+def _get_reg_data(gddp_params, start_date, end_date):
+    url_list = _get_urls(start_date, end_date, 
+                        gddp_params['model'],
+                        gddp_params['scenario'], 
+                        gddp_params['variable'])
+    if len(url_list) != 1:
+        raise ValueError('registry queries should involve exactly one file.') 
+    _, url = url_list[0]
+    ds = _get_dataset(url) 
+    return ds[gddp_params['variable']]
+
+def reg_query(name, params, variable, start_date, end_date, model = None, scenario = None):
+    result_start, result_end = _get_reg_time_bounds(params, start_date, end_date)
+
+    gddp_params = _get_reg_params(variable, model, scenario) 
+    array = _get_reg_data(gddp_params, start_date, end_date)
+
+    lb = params.get('lb') 
+    ub = params.get('ub') 
+    if lb:
+        result = np.ndarray(((result_end - result_start) + 1, 
+                            (ub[0] - lb[0]) + 1, (ub[1] - lb[1] + 1)), 
+                            dtype = array.dtype)
+        index = [slice(result_start, result_end + 1), 
+                slice(lb[0], ub[0] + 1), 
+                slice(lb[1], ub[1] + 1)]
+    else:
+        result = np.ndarray(((result_end - result_start) + 1, 
+                            array.shape[0], array.shape[1]), 
+                            dtype = array.dtype)
+        index = [slice(result_start, result_end + 1), 
+                slice(0, array.shape[0]), 
+                slice(0, array.shape[1])] 
+        result[ :, :, : ] = array[index]
+    return result
+
+def pquery(variable, start_date, end_date, lb, ub, model = 'CESM2', scenario = 'ssp585', **kwargs):
+    result = _get_cmip6_data(model, scenario, variable, start_date, end_date, lb, ub)
+    return result
 
 def query(name, version, lb, ub):
     start_date, end_date = _get_gddp_time_ranges(version)
-    model, scenario, variable, quality = _get_gddp_params(name)
-    result = _get_cmip6_data(model, scenario, variable, start_date, end_date, lb, ub)
-    return(result)
+    gddp_params = _get_gddp_params(name)
+    result = _get_cmip6_data(start_date, end_date, lb, ub, **gddp_params)
+    return result
+
+"""
+if __name__ == '__main__':
+    params = {'lb' : (100, 200), 
+            'ub' : (150, 230), 
+            'query_start' : '2013-05-02', 
+            'query_end' : '2013-06-03'}
+    #params = {'query_time' : '2013-05-02' }
+    start_date = '2013-01-01'
+    end_date = '2013-12-31'
+    model = 'ACCESS-ESM1-5'
+    scenario = 'historical'
+    variable = 'tas'
+    res = reg_query('foo', params, variable, start_date, end_date, model, scenario)
+    print(res.shape)
+"""
 
 if __name__ == '__main__':
-    s = date(2013, 5, 2)
+    s = date(2013, 5, 2) 
     e = date(2013, 5, 2)
-    start = (s - base_date).days
-    span = (e - s).days
-    lb = (0,0)
-    ub = (599,1399)
+    start =(s - base_date).days
+    span = (e - s).days 
+    lb =(100, 200) 
+    ub =(150, 230)
     version = pack('uint:16, uint:16', start, span).uint
-    res = query(name='cmip6-planetary\\m:ACCESS-ESM1-5,v:tas', version=1, lb=lb, ub=ub)
-    print(res.shape)
-
-
+    res = query(name = 'cmip6-planetary\\m:ACCESS-ESM1-5,v:tas', version = 1, lb = lb, ub = ub)
+    print(res)

--- a/modules/s3nc_mod.py
+++ b/modules/s3nc_mod.py
@@ -88,10 +88,12 @@ def validate(bucket, path):
     if not path.endswith('.nc'):
         raise ValueError("S3 module can only access netCDF files.")
 
-def reg_query(name, version, lb, ub, params, bucket, path):
+def reg_query(name, params, bucket, path):
     if 'var_name' not in params:
         raise ValueError
     var_name = params['var_name']
+    lb = params.get('lb')
+    ub = params.get('ub')
     cache_entry = f'{cache_base}/{bucket}/{path}'
     if not os.path.exists(cache_entry):
         s3.get(f'{bucket}/{path}', cache_entry)
@@ -121,6 +123,9 @@ def query(name, version, lb, ub):
     return(array[index])
 
 if __name__ == '__main__':
-    var_name = 'goes17\\RadM/M1/C2/Rad'
+    var_name = 'Rad'
     version = 505081608
-    print(query(var_name, version, (1,1), (4,2)))
+    bucket = 'noaa-goes17'
+    path = 'ABI-L1b-RadM/2020/215/15/OR_ABI-L1b-RadM1-M6C04_G17_s20202151508255_e20202151508312_c20202151508354.nc'
+    params = {'version':version, 'var_name': var_name, 'lb':(1,1), 'ub':(4,2)}
+    print(reg_query('foo', params, bucket, path))

--- a/modules/url_mod.py
+++ b/modules/url_mod.py
@@ -29,8 +29,12 @@ def _get_url_array(url, name, var_name):
     data = Dataset(cache_entry)
     return(data[var_name])
 
-def reg_query(name, version, lb, ub, params, url):
+def reg_query(name, params, url):
+    if 'var_name' not in params:
+        raise ValueError
     var_name = params['var_name']
+    lb = params.get('lb')
+    ub = params.get('ub')
     array = _get_url_array(url, name, var_name)
     if lb:
         index = [ slice(lb[x], ub[x]+1) for x in range(len(lb)) ]
@@ -50,5 +54,6 @@ def query(name, version, lb, ub):
 
 if __name__ == '__main__':
     url = 'https://www.unidata.ucar.edu/software/netcdf/examples/sresa1b_ncar_ccsm3-example.nc'
-    a = reg_query('foo', 0, (10, 10), (20,30), {'var_name':'area'}, url)
+    params = {'lb':(10,10), 'ub':(20,20), 'var_name':'area'}
+    a = reg_query('foo', params, url)
     print(a)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,7 +5,7 @@ if(HAVE_DRC)
 endif()
 
 # list of source files
-set(dspaces-src util.c bbox.c ss_data.c dspaces-client.c dspaces-ops.c)
+set(dspaces-src util.c bbox.c ss_data.c dspaces-client.c dspaces-ops.c dspaces-logging.c)
 
 # load package helper for generating cmake CONFIG packages
 include (CMakePackageConfigHelpers)


### PR DESCRIPTION
Introduces the dspaces_get_mod() client API method, which allows the user to directly provide module parameters to DataSpaces.

The user provides an array of arguments, each of which is a user-populated structs consisting of name, type, and value.

Adapts exisitung modules for this method of access.